### PR TITLE
Add customPadding prop

### DIFF
--- a/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
+++ b/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
@@ -83,6 +83,11 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
                 .emit("onError", error);
     }
 
+    @ReactProp(name = "customPadding")
+    public void setCustomPadding(AirMapView view, ReadableMap customPadding) {
+      view.setPadding(customPadding.getInt("left"), customPadding.getInt("top"), customPadding.getInt("right"), customPadding.getInt("bottom"));
+    }
+
     @ReactProp(name = "region")
     public void setRegion(AirMapView view, ReadableMap region) {
         view.setRegion(region);
@@ -93,7 +98,7 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
         int typeId = MAP_TYPES.get(mapType);
         view.map.setMapType(typeId);
     }
-    
+
     @ReactProp(name = "customMapStyleString")
     public void setMapStyle(AirMapView view, @Nullable String customMapStyleString) {
         view.map.setMapStyle(new MapStyleOptions(customMapStyleString));

--- a/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -310,6 +310,10 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
         }
     }
 
+    public void setCustomPadding(ReadableMap customPadding) {
+      map.setPadding(customPadding.getInt("left"), customPadding.getInt("top"), customPadding.getInt("right"), customPadding.getInt("bottom"));
+    }
+
     public void setShowsUserLocation(boolean showUserLocation) {
         this.showUserLocation = showUserLocation; // hold onto this for lifecycle handling
         if (hasPermissions()) {

--- a/components/MapView.js
+++ b/components/MapView.js
@@ -70,6 +70,14 @@ const propTypes = {
   customMapStyle: PropTypes.array,
 
   /**
+   * A json object that describes the padding for controls, logo, etc of the map
+   *
+   * https://developers.google.com/maps/documentation/ios-sdk/map
+   * https://developers.google.com/maps/documentation/android-api/map#map_padding
+   */
+  customPadding: EdgeInsetsPropType,
+
+  /**
    * A json string that describes the style of the map
    * https://developers.google.com/maps/documentation/ios-sdk/styling#use_a_string_resource
    * https://developers.google.com/maps/documentation/android-api/styling

--- a/ios/AirGoogleMaps/AIRGoogleMap.h
+++ b/ios/AirGoogleMaps/AIRGoogleMap.h
@@ -14,6 +14,7 @@
 
 @interface AIRGoogleMap : GMSMapView
 
+@property (nonatomic, assign) UIEdgeInsets customPadding;
 // TODO: don't use MK region?
 @property (nonatomic, assign) MKCoordinateRegion initialRegion;
 @property (nonatomic, assign) MKCoordinateRegion region;

--- a/ios/AirGoogleMaps/AIRGoogleMap.m
+++ b/ios/AirGoogleMaps/AIRGoogleMap.m
@@ -134,6 +134,10 @@ id regionAsJSON(MKCoordinateRegion region) {
 }
 #pragma clang diagnostic pop
 
+- (void)setCustomPadding(UIEdgeInsets)customPadding {
+  self.padding = customPadding;
+}
+
 - (void)setInitialRegion:(MKCoordinateRegion)initialRegion {
   if (_initialRegionSet) return;
   _initialRegionSet = true;

--- a/ios/AirGoogleMaps/AIRGoogleMapManager.m
+++ b/ios/AirGoogleMaps/AIRGoogleMapManager.m
@@ -45,6 +45,7 @@ RCT_EXPORT_MODULE()
   return map;
 }
 
+RCT_EXPORT_VIEW_PROPERTY(customPadding, UIEdgeInsets)
 RCT_EXPORT_VIEW_PROPERTY(initialRegion, MKCoordinateRegion)
 RCT_EXPORT_VIEW_PROPERTY(region, MKCoordinateRegion)
 RCT_EXPORT_VIEW_PROPERTY(showsBuildings, BOOL)


### PR DESCRIPTION
We need to be able to set the `padding` attribute of the native maps for both iOS and Android however `padding` is a reserved prop name so I've added this as `customPadding`. 